### PR TITLE
Add batch submission probability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,35 +27,39 @@ documentation.
 
 The following table details the environment variable configuration options.
 
-+------------------------------+--------------------------------------------------+---------------+
-| Variable                     | Definition                                       | Default       |
-+==============================+==================================================+===============+
-| ``INFLUXDB_SCHEME``          | The URL request scheme for making HTTP requests  | ``https``     |
-+------------------------------+--------------------------------------------------+---------------+
-| ``INFLUXDB_HOST``            | The InfluxDB server hostname                     | ``localhost`` |
-+------------------------------+--------------------------------------------------+---------------+
-| ``INFLUXDB_PORT``            | The InfluxDB server port                         | ``8086``      |
-+------------------------------+--------------------------------------------------+---------------+
-| ``INFLUXDB_USER``            | The InfluxDB server username                     |               |
-+------------------------------+--------------------------------------------------+---------------+
-| ``INFLUXDB_PASSWORD``        | The InfluxDB server password                     |               |
-+------------------------------+--------------------------------------------------+---------------+
-| ``INFLUXDB_ENABLED``         | Set to ``false`` to disable InfluxDB support     | ``true``      |
-+------------------------------+--------------------------------------------------+---------------+
-| ``INFLUXDB_INTERVAL``        | How many milliseconds to wait before submitting  | ``60000``     |
-|                              | measurements when the buffer has fewer than      |               |
-|                              | ``INFLUXDB_TRIGGER_SIZE`` measurements.          |               |
-+------------------------------+--------------------------------------------------+---------------+
-| ``INFLUXDB_MAX_BATCH_SIZE``  | Max # of measurements to submit in a batch       | ``10000``     |
-+------------------------------+--------------------------------------------------+---------------+
-| ``INFLUXDB_MAX_BUFFER_SIZE`` | Limit of measurements in a buffer before new     | ``25000``     |
-|                              | measurements are discarded.                      |               |
-+------------------------------+--------------------------------------------------+---------------+
-| ``INFLUXDB_TRIGGER_SIZE``    | The number of metrics in the buffer to trigger   | ``60000``     |
-|                              | the submission of a batch.                       |               |
-+------------------------------+--------------------------------------------------+---------------+
-| ``INFLUXDB_TAG_HOSTNAME``    | Include the hostname as a tag in the measurement | ``true``      |
-+------------------------------+--------------------------------------------------+---------------+
++---------------------------------+--------------------------------------------------+---------------+
+| Variable                        | Definition                                       | Default       |
++=================================+==================================================+===============+
+| ``INFLUXDB_SCHEME``             | The URL request scheme for making HTTP requests  | ``https``     |
++---------------------------------+--------------------------------------------------+---------------+
+| ``INFLUXDB_HOST``               | The InfluxDB server hostname                     | ``localhost`` |
++---------------------------------+--------------------------------------------------+---------------+
+| ``INFLUXDB_PORT``               | The InfluxDB server port                         | ``8086``      |
++---------------------------------+--------------------------------------------------+---------------+
+| ``INFLUXDB_USER``               | The InfluxDB server username                     |               |
++---------------------------------+--------------------------------------------------+---------------+
+| ``INFLUXDB_PASSWORD``           | The InfluxDB server password                     |               |
++---------------------------------+--------------------------------------------------+---------------+
+| ``INFLUXDB_ENABLED``            | Set to ``false`` to disable InfluxDB support     | ``true``      |
++---------------------------------+--------------------------------------------------+---------------+
+| ``INFLUXDB_INTERVAL``           | How many milliseconds to wait before submitting  | ``60000``     |
+|                                 | measurements when the buffer has fewer than      |               |
+|                                 | ``INFLUXDB_TRIGGER_SIZE`` measurements.          |               |
++---------------------------------+--------------------------------------------------+---------------+
+| ``INFLUXDB_MAX_BATCH_SIZE``     | Max # of measurements to submit in a batch       | ``10000``     |
++---------------------------------+--------------------------------------------------+---------------+
+| ``INFLUXDB_MAX_BUFFER_SIZE``    | Limit of measurements in a buffer before new     | ``25000``     |
+|                                 | measurements are discarded.                      |               |
++------------------------------+-----------------------------------------------------+---------------+
+| ``INFLUXDB_SAMPLE_PROBABILITY`` | A value that is >= 0 and <= 1.0 that specifies   | ``1.0``       |
+|                                 | the probability that a batch will be submitted   |               |
+|                                 | to InfluxDB or dropped.                          |               |
++---------------------------------+--------------------------------------------------+---------------+
+| ``INFLUXDB_TRIGGER_SIZE``       | The number of metrics in the buffer to trigger   | ``60000``     |
+|                                 | the submission of a batch.                       |               |
++---------------------------------+--------------------------------------------------+---------------+
+| ``INFLUXDB_TAG_HOSTNAME``       | Include the hostname as a tag in the measurement | ``true``      |
++---------------------------------+--------------------------------------------------+---------------+
 
 Mixin Configuration
 ^^^^^^^^^^^^^^^^^^^

--- a/tests/install_tests.py
+++ b/tests/install_tests.py
@@ -139,6 +139,18 @@ class SetConfigurationTestCase(base.AsyncTestCase):
         influxdb.set_timeout(expectation)
         self.assertEqual(influxdb._timeout_interval, expectation)
 
+    def test_set_sample_probability(self):
+        influxdb.install()
+        expectation = random.random()
+        influxdb.set_sample_probability(expectation)
+        self.assertEqual(influxdb._sample_probability, expectation)
+
+    def test_set_invalid_sample_probability(self):
+        influxdb.install()
+        with self.assertRaises(ValueError):
+            influxdb.set_sample_probability(2.0)
+            influxdb.set_sample_probability(-1.0)
+
 
 class MeasurementTests(unittest.TestCase):
 


### PR DESCRIPTION
Too many requests == dead InfluxDB server. This adds the ability to configure a probability for submitting a batch of measurements into InfluxDB.