### PR TITLE
Pin coverage to >=4.1,<5

### DIFF
--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -1,6 +1,6 @@
 mock>=1.0.1,<2
 nose>=1.3,<2
-coverage>=3.7,<4.1
+coverage>=4.1,<5
 codecov
 pycurl==7.43.0
 -r installation.txt


### PR DESCRIPTION
Coverage fails to generate with `coverage<4.1`. Pinning to a more recent version resolves it.

```
Name                    Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------
sprockets_influxdb.py   IndexError: pop from empty list
Traceback (most recent call last):
  File "/Users/andrewr/Code/GitHub/nvllsvm/sprockets-influxdb/env/bin/nosetests", line 11, in <module>
    sys.exit(run_exit())
  File "/Users/andrewr/Code/GitHub/nvllsvm/sprockets-influxdb/env/lib/python3.6/site-packages/nose/core.py", line 121, in __init__
    **extra_args)
  File "/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/unittest/main.py", line 95, in __init__
    self.runTests()
  File "/Users/andrewr/Code/GitHub/nvllsvm/sprockets-influxdb/env/lib/python3.6/site-packages/nose/core.py", line 207, in runTests
    result = self.testRunner.run(self.test)
  File "/Users/andrewr/Code/GitHub/nvllsvm/sprockets-influxdb/env/lib/python3.6/site-packages/nose/core.py", line 66, in run
    result.printErrors()
  File "/Users/andrewr/Code/GitHub/nvllsvm/sprockets-influxdb/env/lib/python3.6/site-packages/nose/result.py", line 110, in printErrors
    self.config.plugins.report(self.stream)
  File "/Users/andrewr/Code/GitHub/nvllsvm/sprockets-influxdb/env/lib/python3.6/site-packages/nose/plugins/manager.py", line 99, in __call__
    return self.call(*arg, **kw)
  File "/Users/andrewr/Code/GitHub/nvllsvm/sprockets-influxdb/env/lib/python3.6/site-packages/nose/plugins/manager.py", line 167, in simple
    result = meth(*arg, **kw)
  File "/Users/andrewr/Code/GitHub/nvllsvm/sprockets-influxdb/env/lib/python3.6/site-packages/nose/plugins/cover.py", line 190, in report
    self.coverInstance.report(modules, file=stream)
  File "/Users/andrewr/Code/GitHub/nvllsvm/sprockets-influxdb/env/lib/python3.6/site-packages/coverage/control.py", line 966, in report
    return reporter.report(morfs, outfile=file)
  File "/Users/andrewr/Code/GitHub/nvllsvm/sprockets-influxdb/env/lib/python3.6/site-packages/coverage/summary.py", line 116, in report
    raise CoverageException("No data to report.")
coverage.misc.CoverageException: No data to report.
```