### PR TITLE
Add support for Tornado >= 4.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ env2
 env3
 .idea
 docs/_build
+.tox
+.coverage*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 install:
  - pip install -r requires/testing.txt
  - pip install wheel
-script: nosetests --with-coverage
+script: tox
 after_success:
  - codecov
 deploy:

--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -3,4 +3,5 @@ nose>=1.3,<2
 coverage>=3.7,<4.1
 codecov
 pycurl==7.43.0
+tox>=2.9,<3
 -r installation.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist =
+    tornado42
+    tornado45
+
+[testenv]
+setenv =
+    COVERAGE_FILE=.coverage.{envname}
+commands =
+    nosetests --with-coverage
+
+[testenv:tornado42]
+deps =
+    coverage
+    mock
+    nose
+    tornado==4.2.1
+
+[testenv:tornado45]
+deps =
+    coverage
+    mock
+    nose
+    tornado==4.5.3


### PR DESCRIPTION
Tornado 4.5 changed request routing in a breaking way. This adds support for the new behavior while preserving existing behavior for older versions of Tornado.