### PR TITLE
Support Tornado 5.1

### DIFF
--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,1 +1,1 @@
-tornado>4.0,<5
+tornado>4.0,<6

--- a/sprockets_influxdb.py
+++ b/sprockets_influxdb.py
@@ -222,7 +222,7 @@ def flush():
     :rtype: :class:`~tornado.concurrent.Future`
 
     """
-    flush_future = concurrent.TracebackFuture()
+    flush_future = concurrent.Future()
     if _batch_future and not _batch_future.done():
         LOGGER.debug('Flush waiting on incomplete _batch_future')
         _flush_wait(flush_future, _batch_future)
@@ -696,7 +696,7 @@ def _write_measurements():
     """
     global _timeout, _writing
 
-    future = concurrent.TracebackFuture()
+    future = concurrent.Future()
 
     if _writing:
         LOGGER.warning('Currently writing measurements, skipping write')

--- a/tests/base.py
+++ b/tests/base.py
@@ -38,7 +38,6 @@ def clear_influxdb_module():
     influxdb._dirty = False
     influxdb._http_client = None
     influxdb._installed = False
-    influxdb._io_loop = None
     influxdb._last_warning = None
     influxdb._measurements = {}
     influxdb._max_batch_size = 5000

--- a/tests/install_tests.py
+++ b/tests/install_tests.py
@@ -41,10 +41,6 @@ class InstallDefaultsTestCase(base.TestCase):
         self.assertEqual(influxdb._http_client.defaults['user_agent'],
                          influxdb.USER_AGENT)
 
-    def test_set_io_loop(self):
-        global_io_loop = ioloop.IOLoop.current()
-        self.assertEqual(influxdb._io_loop, global_io_loop)
-
     def test_set_submission_interval(self):
         self.assertEqual(influxdb._timeout_interval, 60000)
 
@@ -103,21 +99,6 @@ class SetConfigurationTestCase(base.AsyncTestCase):
         self.assertEqual(influxdb._base_url, expectation)
         self.assertTrue(influxdb._dirty)
 
-    def test_set_io_loop_invalid_raises(self):
-        influxdb.install()
-        with self.assertRaises(ValueError):
-            influxdb.set_io_loop('bad value')
-
-    def test_set_io_loop(self):
-        influxdb.install()
-        previous = influxdb._io_loop
-        io_loop = self.get_new_ioloop()
-
-        influxdb.set_io_loop(io_loop)
-        self.assertEqual(influxdb._io_loop, io_loop)
-        self.assertNotEqual(io_loop, previous)
-        self.assertTrue(influxdb._dirty)
-
     def test_set_max_batch_size(self):
         influxdb.install()
         expectation = random.randint(1000, 100000)
@@ -133,8 +114,7 @@ class SetConfigurationTestCase(base.AsyncTestCase):
 
     @testing.gen_test()
     def test_set_timeout(self):
-        io_loop = self.get_new_ioloop()
-        influxdb.install(io_loop=io_loop)
+        influxdb.install()
         expectation = random.randint(1000, 10000)
         influxdb.set_timeout(expectation)
         self.assertEqual(influxdb._timeout_interval, expectation)

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     tornado42
     tornado45
+    tornado51
 
 [testenv]
 setenv =
@@ -22,3 +23,10 @@ deps =
     mock
     nose
     tornado==4.5.3
+
+[testenv:tornado51]
+deps =
+    coverage
+    mock
+    nose
+    tornado==5.1.1


### PR DESCRIPTION
Tornado 5 removed the ability to pass ioloops as arguments - instead recommending to use `IOLoop.current()`. This pull request changes sprockets-influx to match that pattern.